### PR TITLE
Updating headings for a11y

### DIFF
--- a/pmpro-gift-aid.php
+++ b/pmpro-gift-aid.php
@@ -24,7 +24,7 @@ function pmproga_pmpro_checkout_after_level_cost()
 		$gift_aid = false;
 ?>
 	<hr />
-	<h3>Gift Aid</h3>
+	<h2>Gift Aid</h2>
 	<p>Gift Aid legislation allows us to reclaim 25p of tax on every £1 that you give on your subscription and additional donations. It won't cost you any extra.</p>
 	<input type="checkbox" id="gift_aid" name="gift_aid" value="1" <?php if($gift_aid) echo 'checked="checked"';?> />
 	<label class="pmpro_normal pmpro_clickable" for="gift_aid">Allow Gift Aid to be collected?</label>


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.